### PR TITLE
Fix invalid pathing and update readme

### DIFF
--- a/scripts/initialise_terraform_consul_backend.sh
+++ b/scripts/initialise_terraform_consul_backend.sh
@@ -45,7 +45,7 @@ terraform {
             access_token = "${CONSUL_ACCESS_TOKEN}"
             lock = true
             scheme  = "https"
-            path    = "dev/app1/"
+            path    = "dev/app1"
             ca_file = "/usr/local/bootstrap/certificate-config/consul-ca.pem"
             cert_file = "/usr/local/bootstrap/certificate-config/client.pem"
             key_file = "/usr/local/bootstrap/certificate-config/client-key.pem"

--- a/scripts/install_consul.sh
+++ b/scripts/install_consul.sh
@@ -56,10 +56,10 @@ sudo killall -1 consul &>/dev/null
 # check consul binary
 [ -f /usr/local/bin/consul ] &>/dev/null || {
     pushd /usr/local/bin
-    [ -f consul_1.3.0_linux_amd64.zip ] || {
-        sudo wget -q https://releases.hashicorp.com/consul/1.3.0/consul_1.3.0_linux_amd64.zip
+    [ -f consul_1.2.3_linux_amd64.zip ] || {
+        sudo wget -q https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip
     }
-    sudo unzip consul_1.3.0_linux_amd64.zip
+    sudo unzip consul_1.2.3_linux_amd64.zip
     sudo chmod +x consul
     popd
 }


### PR DESCRIPTION
# Why is the PR required?

### Issue:

Incorrect path used for statefile location - extra slash `/` at end of path not required and root cause of the 404 errors

## What does this PR do?

Fix 404 errors when using terraform as a remote backend

## How was this PR implemented?

Deleted '/' from end of consul path

## How long did it take?
10 seconds


