### PR TITLE
updated to minimise ACLs required

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "null_resource" "Terraform-Consul-Backend-Demo" {
 terraform {
         backend "consul" {
             address = "127.0.0.1:8321"
-            access_token = "9970057b-5cad-a350-af71-f0cf867805c6"
+            access_token = "575d6d21-b08d-1975-4d37-a4222fee766c"
             lock = true
             scheme  = "https"
             path    = "dev/app1"

--- a/scripts/consul_enable_acls.sh
+++ b/scripts/consul_enable_acls.sh
@@ -132,7 +132,7 @@ step5_create_kv_app_token () {
     "{
       \"Name\": \"${1}\",
       \"Type\": \"client\",
-      \"Rules\": \"key \\\"dev/app1\\\" { policy = \\\"write\\\" } node \\\"\\\" { policy = \\\"write\\\" } service \\\"\\\" { policy = \\\"write\\\" } query \\\"\\\" { policy = \\\"write\\\" } event \\\"\\\" { policy = \\\"write\\\" } session \\\"\\\" { policy = \\\"write\\\" }\"
+      \"Rules\": \"key \\\"dev/app1\\\" { policy = \\\"write\\\" } node \\\"\\\" { policy = \\\"write\\\" } session \\\"\\\" { policy = \\\"write\\\" }\"
     }" https://127.0.0.1:8321/v1/acl/create | jq -r .ID)
 
   echo "The ACL token for ${1} is => ${APPTOKEN}"


### PR DESCRIPTION
# Why is the PR required?

Tighten the scope of the ACL to access consul

## What does this PR do?

Reduces the policies that have been enabled on the TF backend token

## How was this PR implemented?

https://github.com/allthingsclowd/Terraform_Consul_Backend_Configuration/compare/minimal-rules-required?expand=1#diff-06cdbbbb72085c922e7a548308dce2dd

## How long did it take?

5 minutes


